### PR TITLE
APIs: fix typo in function names

### DIFF
--- a/APIs/bus-booking.php
+++ b/APIs/bus-booking.php
@@ -62,4 +62,4 @@
 	}
 
 	// incorrect parameters passed
-	invalidParametesError();
+	invalidParametersError();

--- a/APIs/inc/responses/errors.php
+++ b/APIs/inc/responses/errors.php
@@ -17,7 +17,7 @@
 	}
 
 
-	function invalidParametesError(){
+	function invalidParametersError(){
 		$error = baseError(400, "Invlid parameters passed!");
 		echo $error;
 	}

--- a/APIs/places-api.php
+++ b/APIs/places-api.php
@@ -39,10 +39,10 @@
 			}
 		} else {
 			// incorrect parameters passed
-			invalidParametesError();
+			invalidParametersError();
 		}
 	} else {
 		// incorrect parameters passed
-		invalidParametesError();
+		invalidParametersError();
 	}
 


### PR DESCRIPTION
I believe an "r" is missing in the function name :P