### PR TITLE
APIs: fix typo in function names (missed a file)

### DIFF
--- a/APIs/city/trends/twitter.php
+++ b/APIs/city/trends/twitter.php
@@ -46,5 +46,5 @@ if($city_id > 0){
 if(isset($final_response)){
 	echo json_encode($final_response, true);
 } else {
-	invalidParametesError();
+	invalidParametersError();
 }


### PR DESCRIPTION
Sorry, I missed a file in pull request #35. This should be all.